### PR TITLE
Improve death messages

### DIFF
--- a/src/main/java/dev/cammiescorner/armaments/Armaments.java
+++ b/src/main/java/dev/cammiescorner/armaments/Armaments.java
@@ -7,6 +7,7 @@ import dev.upcraft.sparkweave.api.registry.RegistryService;
 import net.fabricmc.fabric.api.event.player.UseItemCallback;
 import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
 import net.fabricmc.fabric.api.loot.v2.LootTableEvents;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.damage.DamageType;
@@ -161,7 +162,7 @@ public class Armaments implements ModInitializer {
 		return new DamageSource(getDamageTypeHolder(world, Armaments.ECHO));
 	}
 
-	public static DamageSource pokeyDamage(World world) {
-		return new DamageSource(getDamageTypeHolder(world, Armaments.POKEY));
+	public static DamageSource pokeyDamage(World world, Entity source) {
+		return new DamageSource(getDamageTypeHolder(world, Armaments.POKEY), source);
 	}
 }

--- a/src/main/java/dev/cammiescorner/armaments/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/cammiescorner/armaments/mixin/LivingEntityMixin.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 
 @Mixin(LivingEntity.class)
 public abstract class LivingEntityMixin extends Entity {
+
 	@Unique private final EchoComponent echo = getComponent(ModComponents.ECHO);
 
 	public LivingEntityMixin(EntityType<?> variant, World world) {
@@ -48,7 +49,7 @@ public abstract class LivingEntityMixin extends Entity {
 			if(stack.isOf(ModItems.ECHO_DAGGER.get()))
 				return Armaments.echoDamage(getWorld());
 			if(stack.isOf(ModItems.ELDER_GUARDIAN_SPIKE.get()))
-				return Armaments.pokeyDamage(getWorld());
+				return Armaments.pokeyDamage(getWorld(), source.getSource());
 		}
 
 		return source;

--- a/src/main/resources/assets/armaments/lang/en_us.json
+++ b/src/main/resources/assets/armaments/lang/en_us.json
@@ -8,5 +8,6 @@
 	"effect.armaments.echo": "Echo",
 
 	"death.attack.armaments.echo": "%s died to an Echo",
+	"death.attack.armaments.echo.player": "%s died to an Echo whilst fighting %s",
 	"death.attack.armaments.pokey": "%s was poked to death"
 }

--- a/src/main/resources/assets/armaments/lang/en_us.json
+++ b/src/main/resources/assets/armaments/lang/en_us.json
@@ -9,5 +9,6 @@
 
 	"death.attack.armaments.echo": "%s died to an Echo",
 	"death.attack.armaments.echo.player": "%s died to an Echo whilst fighting %s",
-	"death.attack.armaments.pokey": "%s was poked to death"
+	"death.attack.armaments.pokey": "%s was poked to death by %s",
+	"death.attack.armaments.pokey.item": "%s was poked to death by %s using %s"
 }


### PR DESCRIPTION
First change is a new death message for dying of an echo while fighting, so this shouldn't happen anymore:
![death attack armaments echo player](https://github.com/CammiePone/Armaments/assets/46634118/3e38bb61-95c9-4a44-87ec-aa8f60068a8c)

Second change is so pokey damage does the same thing as Minecraft's default death by attack damage types, and displays the attacker (and potential renamed item) in death messages, like this!
![image](https://github.com/CammiePone/Armaments/assets/46634118/4e243f16-a429-49c7-a884-04c833ea209d)
